### PR TITLE
corrects problem of spurious first line and doc. for map2_mx

### DIFF
--- a/mathcomp/algebra/matrix.v
+++ b/mathcomp/algebra/matrix.v
@@ -1,4 +1,3 @@
-
 (* (c) Copyright 2006-2016 Microsoft Corporation and Inria.                  *)
 (* Distributed under the terms of CeCILL-B.                                  *)
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq choice.
@@ -36,8 +35,8 @@ From mathcomp Require Import div prime binomial ssralg finalg zmodp countalg.
 (*     map_mx f A == the pointwise image of A by f, i.e., the matrix Af       *)
 (*                   congruent to A with Af i j = f (A i j) for all i and j.  *)
 (*     map2_mx f A B == the pointwise image of A and B by f, i.e., the matrix *)
-(*                     ABf congruent to A with ABf i j = f (A i j) for all i  *)
-(*                     and j.                                                 *)
+(*                     ABf congruent to A with ABf i j = f (A i j) (B i j)    *)
+(*                     for all i and j.                                       *)
 (*            A^T == the matrix transpose of A.                               *)
 (*        row i A == the i'th row of A (this is a row vector).                *)
 (*        col j A == the j'th column of A (a column vector).                  *)


### PR DESCRIPTION
##### Motivation for this change

<!-- please explain your reason for doing this change -->

This is the correction I propose, only a correction to the documentation.  It also remove the spurious line that Cyril was
noting

##### Things done/to do

<!-- please fill in the following checklist -->
- [ ] added corresponding entries in `CHANGELOG_UNRELEASED.md` (do not edit former entries)
- [ x] added corresponding documentation in the headers
<!-- Cross-out the above items using ~crossed out item~ if they happen not to be relevant -->
<!-- You may also add more items to explain what you did and what remains to do -->

<!-- leave this note as a reminder to reviewers -->
##### Automatic note to reviewers

Read [this Checklist](https://github.com/math-comp/math-comp/wiki/Checklist-for-following,-reviewing-and-playing-with-a-PR#checklist-for-reviewing-a-pr) and make sure there is a milestone.
